### PR TITLE
Simplify Table of Contents intersection logic & tweak styling

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -384,19 +384,20 @@ h2.heading {
 	padding: 1px 0 1px 0;
 	padding-inline-start: 1rem;
 	border-inline-start: 4px solid var(--theme-divider);
-	transition: border-inline-start-color 100ms ease-out;
+	transition: border-inline-start-color 100ms ease-out, background-color 200ms ease-out;
+}
+.current-header-link {
+	background-color: var(--theme-bg-accent);
 }
 
 .header-link:hover,
 .header-link:focus,
-.header-link:focus-within,
-.current-header-link {
+.header-link:focus-within {
 	border-inline-start-color: var(--theme-accent-secondary);
 }
 
 .header-link:hover a,
-.header-link a:focus,
-.current-header-link {
+.header-link a:focus {
 	color: var(--theme-text);
 	text-decoration: underline;
 }
@@ -410,6 +411,9 @@ h2.heading {
 	display: inline-flex;
 	gap: 0.5em;
 	width: 100%;
+}
+.current-header-link a {
+	color: var(--theme-text);
 }
 
 .header-link.depth-3 {

--- a/src/components/RightSidebar/TableOfContents.tsx
+++ b/src/components/RightSidebar/TableOfContents.tsx
@@ -3,7 +3,7 @@ import { h, Fragment } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
 
 interface Props {
-	headers: any[];
+	headers: { depth: number; slug: string; text: string }[];
 	labels: {
 		onThisPage: string;
 		overview: string;
@@ -11,76 +11,47 @@ interface Props {
 }
 
 const TableOfContents: FunctionalComponent<Props> = ({ headers = [], labels }) => {
-	const itemOffsets = useRef([]);
-	const [activeId, setActiveId] = useState<string>(undefined);
+	headers = [{ depth: 2, slug: 'overview', text: labels.overview }, ...headers].filter(({ depth }) => depth > 1 && depth < 4);
+	const toc = useRef<HTMLUListElement>();
+	const [currentID, setCurrentID] = useState('overview');
 
 	useEffect(() => {
-		const getItemOffsets = () => {
-			const titles = document.querySelectorAll('article :is(h1, h2, h3, h4)');
-			itemOffsets.current = Array.from(titles).map((title) => ({
-				id: title.id,
-				topOffset: title.getBoundingClientRect().top + window.scrollY,
-			}));
+		if (!toc.current) return;
+
+		const setCurrent: IntersectionObserverCallback = (entries) => {
+			for (const entry of entries) {
+				if (entry.isIntersecting) {
+					setCurrentID(entry.target.id);
+					break;
+				}
+			}
 		};
 
-		const addObservers = () => {
-			const observerOptions = {
-				root: null,
-				rootMargin: '0px',
-				threshold: [1],
-			};
-
-			const setCurrent = (element) => {
-				const tocItems = document.querySelectorAll('.sidebar-nav #toc li');
-
-				element.map((e) => {
-					const currentHeadingLink = document.querySelector(`.sidebar-nav #toc li a[href="#${e.target.id}"]`);
-
-					if (e.isIntersecting === true && currentHeadingLink !== null) {
-						tocItems.forEach((item) => {
-							item.classList.remove('current-header-link');
-
-							if (item.contains(currentHeadingLink)) {
-								item.classList.add('current-header-link');
-							}
-						});
-					}
-				});
-			};
-
-			const observeHeadings = new IntersectionObserver(setCurrent, observerOptions);
-
-			const headings = document.querySelectorAll('article :is(h1,h2,h3,h4):not(nav.sidebar-nav)');
-
-			headings.forEach((header) => {
-				observeHeadings.observe(header);
-			});
+		const observerOptions: IntersectionObserverInit = {
+			// Negative top margin accounts for `scroll-margin`.
+			// Negative bottom margin means heading needs to be towards top of viewport to trigger intersection.
+			rootMargin: '-100px 0% -66%',
+			threshold: 1,
 		};
 
-		getItemOffsets();
-		window.addEventListener('resize', getItemOffsets);
+		const headingsObserver = new IntersectionObserver(setCurrent, observerOptions);
 
-		addObservers();
+		// Observe all the headings in the main page content.
+		document.querySelectorAll('article :is(h1,h2,h3)').forEach((h) => headingsObserver.observe(h));
 
-		return () => {
-			window.removeEventListener('resize', getItemOffsets);
-		};
-	}, []);
+		// Stop observing when the component is unmounted.
+		return () => headingsObserver.disconnect();
+	}, [toc.current]);
 
 	return (
 		<>
 			<h2 class="heading">{labels.onThisPage}</h2>
-			<ul id="toc">
-				<li class={`header-link depth-2 ${activeId === 'overview' ? 'active' : ''}`.trim()}>
-					<a href="#overview">{labels.overview}</a>
-				</li>
-				{headers
-					.filter(({ depth }) => depth > 1 && depth < 4)
-					.map((header) => (
-						<li class={`header-link depth-${header.depth} ${activeId === header.slug ? 'active' : ''}`.trim()}>
-							<a href={`#${header.slug}`}>{header.text}</a>
-						</li>
-					))}
+			<ul ref={toc}>
+				{headers.map(({ depth, slug, text }) => (
+					<li class={`header-link depth-${depth} ${currentID === slug ? 'current-header-link' : ''}`.trim()}>
+						<a href={`#${slug}`}>{text}</a>
+					</li>
+				))}
 			</ul>
 		</>
 	);


### PR DESCRIPTION
Iterating on withastro/docs#419

Thanks for getting this going! Hope you don’t mind me playing around with your code. This PR does the following:

- Use “the Preact way” of getting a ref to the contents list instead of using a query selector
- Use a state hook to set the current class instead of setting with  native browser APIs
- Don’t observe h4 as those aren’t included in the table of contents
- Consolidate the headers rendering so the overview link is treated the same as other items in the contents
- Use the `rootMargin` option to the intersection observer to improve the targeting of which heading is currently highlighted
- Tweak the styling so that the current section matches the styling of the left sidebar’s “current” link